### PR TITLE
Expand playfield and disable mouse control

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,19 @@
     <div class="hud__item">Lives: <span id="lives">3</span></div>
   </div>
 
-  <canvas id="gameCanvas" width="960" height="600" aria-label="Breakout style game canvas"></canvas>
+  <canvas
+    id="gameCanvas"
+    width="1080"
+    height="720"
+    aria-label="Breakout style game canvas"
+  ></canvas>
 
   <div id="startScreen" class="overlay">
     <div class="overlay__content">
       <h1>Breakout: Levels Edition</h1>
       <p>Smash through the assessment levels before they smash your morale.</p>
       <ul class="overlay__list">
-        <li>Move with your mouse or the ← → keys (A / D).</li>
+        <li>Move with the ← → keys (A / D).</li>
         <li>You have 3 lives to clear the grid.</li>
         <li>Earn points for every outdated level you obliterate.</li>
       </ul>

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ const brickSettings = {
   height: 24,
   padding: 5,
   topOffset: 90,
-  leftOffset: 60,
+  leftOffset: 138,
 };
 
 const statusStyles = {
@@ -373,13 +373,6 @@ function handleKeyUp(event) {
   }
 }
 
-function handleMouseMove(event) {
-  const rect = canvas.getBoundingClientRect();
-  const scaleX = canvas.width / rect.width;
-  const x = (event.clientX - rect.left) * scaleX;
-  paddle.x = Math.max(0, Math.min(canvas.width - paddle.width, x - paddle.width / 2));
-}
-
 startButton.addEventListener('click', () => {
   startGame();
 });
@@ -390,7 +383,6 @@ restartButton.addEventListener('click', () => {
 
 window.addEventListener('keydown', handleKeyDown);
 window.addEventListener('keyup', handleKeyUp);
-canvas.addEventListener('mousemove', handleMouseMove);
 
 function gameLoop() {
   update();

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@ canvas {
 }
 
 .hud {
-  width: 960px;
+  width: 1080px;
   max-width: 100%;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- enlarge the game canvas to 1080x720 so the ball has a longer drop
- center the brick grid and update HUD width to match the wider playfield
- remove mouse movement controls and update the instructions to reflect keyboard-only input

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d530da03788333bbb59d4a627ee08a