### PR TITLE
Adjust brick status mapping for top and bottom rows

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,6 +112,12 @@ function createBricks() {
 }
 
 function determineStatus(row, col) {
+  if (row === 0) {
+    return 'Expected';
+  }
+  if (row === brickSettings.rows - 1) {
+    return 'Below';
+  }
   const diagonalBias = col - row;
   if (diagonalBias <= -3) {
     return 'Above';


### PR DESCRIPTION
## Summary
- ensure the top brick row is always marked Expected
- ensure the bottom brick row is always marked Below to match the reference grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d534253ef48333b1d6b5bb62d7e298