### PR TITLE
Add InstantDB-powered leaderboard with player name gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,18 @@
         <li>You have 3 lives to clear the grid.</li>
         <li>Earn points for every outdated level you obliterate.</li>
       </ul>
+      <label class="overlay__label" for="playerName">Enter your name to join the leaderboard</label>
+      <input
+        id="playerName"
+        class="overlay__input"
+        type="text"
+        name="playerName"
+        maxlength="32"
+        placeholder="Your name"
+        autocomplete="off"
+        required
+      />
+      <p id="nameError" class="overlay__error" aria-live="polite"></p>
       <button id="startButton">Start</button>
     </div>
   </div>
@@ -40,9 +52,14 @@
       <p>Your time: <span id="finalTime">0:00</span></p>
       <p class="overlay__hint">Press space or tap the button to try again.</p>
       <button id="restartButton">Play Again</button>
+      <div class="leaderboard" aria-live="polite">
+        <h3 class="leaderboard__title">Leaderboard</h3>
+        <p id="leaderboardStatus" class="leaderboard__status"></p>
+        <ol id="leaderboardList" class="leaderboard__list"></ol>
+      </div>
     </div>
   </div>
 
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -129,3 +129,110 @@ button:hover {
 button:active {
   transform: translateY(0);
 }
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.overlay__label {
+  display: block;
+  margin-top: 20px;
+  margin-bottom: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #cbd5f5;
+  text-align: left;
+}
+
+.overlay__input {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background-color: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.overlay__input:focus {
+  outline: none;
+  border-color: rgba(34, 211, 238, 0.75);
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.25);
+}
+
+.overlay__error {
+  min-height: 24px;
+  margin-top: 8px;
+  color: #f87171;
+  font-size: 0.9rem;
+}
+
+.leaderboard {
+  margin-top: 32px;
+  text-align: left;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.leaderboard__title {
+  font-size: 1.2rem;
+  margin-bottom: 12px;
+  color: #f8fafc;
+}
+
+.leaderboard__status {
+  min-height: 24px;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.leaderboard__list {
+  margin-top: 12px;
+  list-style: none;
+  padding: 0;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.leaderboard__entry {
+  display: grid;
+  grid-template-columns: 32px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.35);
+  margin-bottom: 6px;
+  font-size: 0.95rem;
+}
+
+.leaderboard__entry--current {
+  border: 1px solid rgba(34, 211, 238, 0.65);
+  box-shadow: 0 0 12px rgba(34, 211, 238, 0.25);
+}
+
+.leaderboard__rank {
+  font-weight: 600;
+  color: #38bdf8;
+  text-align: right;
+}
+
+.leaderboard__name {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.leaderboard__score {
+  font-variant-numeric: tabular-nums;
+  color: #facc15;
+}
+
+.leaderboard__time {
+  font-variant-numeric: tabular-nums;
+  color: #cbd5f5;
+}


### PR DESCRIPTION
## Summary
- require players to enter a display name before the game can start and wire up start controls accordingly
- integrate InstantDB to submit finished runs and render a top 20 leaderboard on the end screen
- style the new name input and leaderboard presentation to match the game's HUD

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_b_68d5423f38148333ba33e5f354fafe68